### PR TITLE
Bump rake from 13.0.1 to 13.0.3

Bumps [rake](https://github.com/ruby/rake) from 13.0.1 to 13.0.3.
- [Release notes](https://github.com/ruby/rake/releases)
- [Changelog](https://github.com/ruby/rake/blob/master/History.rdoc)
- [Commits](https://github.com/ruby/rake/compare/v13.0.1...v13.0.3)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (3.1.1)
     rainbow (3.0.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)


### PR DESCRIPTION
Gemfile.lock- [ ] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----Gemfile.lock
